### PR TITLE
Include both DOB and cluster flags

### DIFF
--- a/knownprojects_build/python/upload_dob_match_to_carto.py
+++ b/knownprojects_build/python/upload_dob_match_to_carto.py
@@ -5,7 +5,7 @@ from cartoframes import to_carto
 from shapely import wkb
 import geopandas as gpd
 
-year = 'test'
+year = 'bothflags'
 
 set_default_credentials(
     username=os.environ.get('CARTO_USERNAME'),
@@ -15,11 +15,11 @@ set_default_credentials(
 sql = '''
     select 
         source, project_id, 
-        project_name, project_status, 
+        project_name, project_status, inactive,
         project_type, number_of_units::integer, 
         date, date_type, dcp_projectcompleted,
-        cluster_id, sub_cluster_id, review_flag,
-        inactive, geom
+        cluster_id, sub_cluster_id, dob_multimatch, needs_review,
+        geom
     from dob_review
     order by cluster_id, sub_cluster_id
     '''

--- a/knownprojects_build/sql/dob_match.sql
+++ b/knownprojects_build/sql/dob_match.sql
@@ -41,11 +41,18 @@ multimatch as (
     from matches
     where source = 'DOB'
     group by project_id
-    having count(cluster_id) > 1)
+    having count(cluster_id) > 1),
+multimatchcluster as (
+    select distinct cluster_id
+    from combined_dob
+    where project_id in (select project_id from multimatch)
+)
 select *,
     (case when project_id in 
 	 (select project_id from multimatch) and source='DOB' then 1 
-        else 0 end) as review_flag
+        else 0 end) as dob_multimatch,
+    (case when cluster_id in 
+        (select cluster_id from multimatchcluster) then 1 else 0 end) as needs_review
 	into dob_review
     from combined_dob
 	where cluster_id in (

--- a/knownprojects_build/sql/dob_match.sql
+++ b/knownprojects_build/sql/dob_match.sql
@@ -24,7 +24,7 @@ with matches as (
     b.inactive,
     b.geom
     FROM combined a
-    INNER JOIN dcp_housing b
+    INNER JOIN dcp_housing_proj b
     ON st_intersects(a.geom, b.geom)
     AND split_part(split_part(a.date, '/', 1), '-', 1)::numeric - 1 < extract(year from b.date::timestamp)),
 combined_dob as (


### PR DESCRIPTION
This branch creates a review table that flags DOB jobs matching with more than one cluster as `dob_multimatch`. It also flags the clusters containing those DOB jobs as `needs_review`.