### PR TITLE
After round 1 review, combine cluster & sub into single ID

### DIFF
--- a/knownprojects_build/python/upload_dob_match_to_carto.py
+++ b/knownprojects_build/python/upload_dob_match_to_carto.py
@@ -5,7 +5,7 @@ from cartoframes import to_carto
 from shapely import wkb
 import geopandas as gpd
 
-year = 'test'
+year = 'bothflags'
 
 set_default_credentials(
     username=os.environ.get('CARTO_USERNAME'),
@@ -15,11 +15,11 @@ set_default_credentials(
 sql = '''
     select 
         source, project_id, 
-        project_name, project_status, 
+        project_name, project_status, inactive,
         project_type, number_of_units::integer, 
         date, date_type, dcp_projectcompleted,
-        cluster_id, sub_cluster_id, review_flag,
-        inactive, geom
+        cluster_id, sub_cluster_id, dob_multimatch, needs_review,
+        geom
     from dob_review
     order by cluster_id, sub_cluster_id
     '''

--- a/knownprojects_build/python/upload_dob_match_to_carto.py
+++ b/knownprojects_build/python/upload_dob_match_to_carto.py
@@ -5,7 +5,7 @@ from cartoframes import to_carto
 from shapely import wkb
 import geopandas as gpd
 
-year = 'bothflags'
+year = 'dev'
 
 set_default_credentials(
     username=os.environ.get('CARTO_USERNAME'),
@@ -18,10 +18,10 @@ sql = '''
         project_name, project_status, inactive,
         project_type, number_of_units::integer, 
         date, date_type, dcp_projectcompleted,
-        cluster_id, sub_cluster_id, dob_multimatch, needs_review,
+        development_id, dob_multimatch, needs_review,
         geom
     from dob_review
-    order by cluster_id, sub_cluster_id
+    order by development_id
     '''
 df = gpd.GeoDataFrame.from_postgis(sql, build_engine, geom_col='geom')
 to_carto(df, f'dob_review_{year}', if_exists='replace')

--- a/knownprojects_build/sql/combine.sql
+++ b/knownprojects_build/sql/combine.sql
@@ -6,7 +6,8 @@ create table combined as (
         number_of_units::integer, date, date_type, 
         dcp_projectcompleted, null as portion_built_by_2025, 
         null as portion_built_by_2035, null as portion_built_by_2055, 
-        cluster_id, sub_cluster_id, adjusted_units,
+        cluster_id, sub_cluster_id, cluster_id||'-'||sub_cluster_id as development_id,
+        adjusted_units,
         inactive, geom
     from dcp_application
     union
@@ -16,7 +17,8 @@ create table combined as (
         number_of_units::integer, date, date_type, 
         dcp_projectcompleted, portion_built_by_2025, 
         portion_built_by_2035, portion_built_by_2055, 
-        cluster_id, sub_cluster_id, adjusted_units,
+        cluster_id, sub_cluster_id, cluster_id||'-'||sub_cluster_id as development_id,
+        adjusted_units,
         inactive, geom
     from dcp_planneradded_proj
     union
@@ -26,7 +28,8 @@ create table combined as (
         number_of_units::integer, date, date_type, 
         dcp_projectcompleted, portion_built_by_2025, 
         portion_built_by_2035, portion_built_by_2055, 
-        cluster_id, sub_cluster_id, adjusted_units,
+        cluster_id, sub_cluster_id, cluster_id||'-'||sub_cluster_id as development_id,
+        adjusted_units,
         inactive, geom
     from dcp_n_study_proj
     union
@@ -36,7 +39,8 @@ create table combined as (
         number_of_units::integer, date, date_type, 
         dcp_projectcompleted, portion_built_by_2025, 
         portion_built_by_2035, portion_built_by_2055, 
-        cluster_id, sub_cluster_id, adjusted_units,
+        cluster_id, sub_cluster_id, cluster_id||'-'||sub_cluster_id as development_id,
+        adjusted_units,
         inactive, geom
     from edc_projects_proj
     union
@@ -46,7 +50,8 @@ create table combined as (
         number_of_units::integer, date, date_type, 
         dcp_projectcompleted, portion_built_by_2025, 
         portion_built_by_2035, portion_built_by_2055, 
-        cluster_id, sub_cluster_id, adjusted_units,
+        cluster_id, sub_cluster_id, cluster_id||'-'||sub_cluster_id as development_id,
+        adjusted_units,
         inactive, geom
     from esd_projects_proj
     union
@@ -56,7 +61,8 @@ create table combined as (
         number_of_units::integer, date, date_type, 
         dcp_projectcompleted, portion_built_by_2025, 
         portion_built_by_2035, portion_built_by_2055, 
-        cluster_id, sub_cluster_id, adjusted_units,
+        cluster_id, sub_cluster_id, cluster_id||'-'||sub_cluster_id as development_id,
+        adjusted_units,
         inactive, geom
     from hpd_rfp_proj
     union
@@ -66,7 +72,8 @@ create table combined as (
         number_of_units::integer, date, date_type, 
         dcp_projectcompleted, portion_built_by_2025, 
         portion_built_by_2035, portion_built_by_2055, 
-        cluster_id, sub_cluster_id, adjusted_units,
+        cluster_id, sub_cluster_id, cluster_id||'-'||sub_cluster_id as development_id,
+        adjusted_units,
         inactive, geom
     from hpd_pc_proj
 );

--- a/knownprojects_build/sql/dob_match.sql
+++ b/knownprojects_build/sql/dob_match.sql
@@ -41,11 +41,18 @@ multimatch as (
     from matches
     where source = 'DOB'
     group by project_id
-    having count(cluster_id) > 1)
+    having count(cluster_id) > 1),
+multimatchcluster as (
+    select distinct cluster_id
+    from combined_dob
+    where project_id in (select project_id from multimatch)
+)
 select *,
     (case when project_id in 
 	 (select project_id from multimatch) and source='DOB' then 1 
-        else 0 end) as review_flag
+        else 0 end) as dob_multimatch,
+    (case when cluster_id in 
+        (select cluster_id from multimatchcluster) then 1 else 0 end) as needs_review
 	into dob_review
     from combined_dob
 	where cluster_id in (

--- a/knownprojects_build/sql/dob_match.sql
+++ b/knownprojects_build/sql/dob_match.sql
@@ -17,9 +17,10 @@ with matches as (
     b.dcp_projectcompleted, 
     null as portion_built_by_2025, 
     null as portion_built_by_2035, 
-    null as portion_built_by_2055, 
-    a.cluster_id, 
+    null as portion_built_by_2055,
+    a.cluster_id,
     a.sub_cluster_id, 
+    a.development_id, 
     null as adjusted_units,
     b.inactive,
     b.geom
@@ -34,16 +35,16 @@ combined_dob as (
     select *
 	from combined),
 relevantcluster as (
-	select distinct cluster_id
+	select distinct development_id
 	FROM matches),
 multimatch as (
     select distinct project_id
     from matches
     where source = 'DOB'
     group by project_id
-    having count(cluster_id) > 1),
+    having count(development_id) > 1),
 multimatchcluster as (
-    select distinct cluster_id
+    select distinct development_id
     from combined_dob
     where project_id in (select project_id from multimatch)
 )
@@ -51,11 +52,11 @@ select *,
     (case when project_id in 
 	 (select project_id from multimatch) and source='DOB' then 1 
         else 0 end) as dob_multimatch,
-    (case when cluster_id in 
-        (select cluster_id from multimatchcluster) then 1 else 0 end) as needs_review
+    (case when development_id in 
+        (select development_id from multimatchcluster) then 1 else 0 end) as needs_review
 	into dob_review
     from combined_dob
-	where cluster_id in (
-		select cluster_id 
+	where development_id in (
+		select development_id 
 		from relevantcluster)
-	order by cluster_id, sub_cluster_id;
+	order by development_id;

--- a/knownprojects_build/sql/dob_match.sql
+++ b/knownprojects_build/sql/dob_match.sql
@@ -24,7 +24,7 @@ with matches as (
     b.inactive,
     b.geom
     FROM combined a
-    INNER JOIN dcp_housing b
+    INNER JOIN dcp_housing_proj b
     ON st_intersects(a.geom, b.geom)
     AND split_part(split_part(a.date, '/', 1), '-', 1)::numeric - 1 < extract(year from b.date::timestamp)),
 combined_dob as (


### PR DESCRIPTION
Needing both cluster & sub-cluster IDs to uniquely identify a cluster is unwieldy. This creates a single ID, currently called `development_id`, but name can be changed once CP/HED decide on nomenclature.

This also addresses #43 