### PR TITLE
Count distinct project_ids when setting dob_multimatch

### DIFF
--- a/knownprojects_build/sql/dob_match.sql
+++ b/knownprojects_build/sql/dob_match.sql
@@ -81,7 +81,7 @@ multimatch as (
     from matches
     where source = 'DOB'
     group by record_id
-    having count(project_id) > 1),
+    having count(distinct(project_id)) > 1),
 multimatchcluster as (
     select distinct project_id
     from combined_dob


### PR DESCRIPTION
Fix error where a DOB job that matches with two records in the same project (cluster), but from different sources, gets a dob_multimatch flag.

To correctly set the flag, the two non-DOB records need to have different project_ids even when they have different sources.