### PR TITLE
Removals and DOB additions

### DIFF
--- a/knownprojects_build/05_corrections.sh
+++ b/knownprojects_build/05_corrections.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
 source config.sh
+# Add in records where field=add, then fill in missing attributes
+psql $BUILD_ENGINE -f sql/add_new_records.sql
+psql $BUILD_ENGINE -f sql/phasing.sql
+psql $BUILD_ENGINE -f sql/normalize_status.sql
+psql $BUILD_ENGINE -f sql/assign_boolean.sql
+psql $BUILD_ENGINE -f sql/assign_boro.sql
+
+# Add planner-added projects
 psql $BUILD_ENGINE -f sql/append_planner_added.sql
+
+# Apply corrections
 psql $BUILD_ENGINE -f sql/apply_corrections.sql

--- a/knownprojects_build/sql/add_new_records.sql
+++ b/knownprojects_build/sql/add_new_records.sql
@@ -9,7 +9,7 @@ INSERT INTO kpdb."2020"
         date,
         date_type,
         units_gross,
-        NULL as units_net,
+        coalesce(units_net::integer, units_gross::integer) as units_net,
         NULL as prop_within_5_years,
         NULL as prop_5_to_10_years,
         NULL as prop_after_10_years,
@@ -31,4 +31,25 @@ INSERT INTO kpdb."2020"
     AND record_id NOT IN (SELECT DISTINCT record_id
                         FROM kpdb."2020"));
 
-		
+-- Add previously filtered ZAP based on kpdb_corrections
+
+
+-- Assign stand-alone project IDs for new additions
+WITH
+max_proj AS (
+	SELECT max(split_part(project_id, '-', 1)::integer) AS max_proj_number
+    FROM kpdb."2020"),
+tmp AS (
+	SELECT
+        a.source,
+        a.record_id,
+		a.record_name,
+        (ROW_NUMBER() OVER (ORDER BY record_id) + b.max_proj_number)::text||'-1' as project_id
+    FROM kpdb."2020" a, max_proj b
+    WHERE a.project_id IS NULL)
+UPDATE kpdb_gross."2020" a
+	SET project_id = b.project_id,
+	FROM tmp b
+	WHERE a.source = b.source
+	AND a.record_id = b.record_id
+	AND a.record_name = b.record_name;

--- a/knownprojects_build/sql/add_new_records.sql
+++ b/knownprojects_build/sql/add_new_records.sql
@@ -1,0 +1,34 @@
+-- Add previously filtered DOB based on kpdb_corrections
+INSERT INTO kpdb."2020"
+(SELECT	NULL as project_id,
+        record_id,
+		record_name,
+        NULL as borough,
+        status,
+        type,
+        date,
+        date_type,
+        units_gross,
+        NULL as units_net,
+        NULL as prop_within_5_years,
+        NULL as prop_5_to_10_years,
+        NULL as prop_after_10_years,
+        NULL as within_5_years,
+        NULL as from_5_to_10_years,
+        NULL as after_10_years,
+        NULL as phasing_rationale,
+        NULL as phasing_known,
+        NULL as nycha,
+        NULL as gq,
+        NULL as senior_housing,
+        NULL as assisted_living,
+        inactive,
+        geom
+    FROM dcp_housing_proj
+    WHERE record_id IN (SELECT DISTINCT record_id
+                        FROM kpdb_corrections
+                        WHERE field = 'add')
+    AND record_id NOT IN (SELECT DISTINCT record_id
+                        FROM kpdb."2020"));
+
+		

--- a/knownprojects_build/sql/apply_corrections.sql
+++ b/knownprojects_build/sql/apply_corrections.sql
@@ -2,6 +2,12 @@ UPDATE kpdb_corrections
 SET old_value = nullif(old_value, ' '),
 	new_value = nullif(new_value, ' ');
 
+-- Remove records
+DELETE FROM kpdb."2020" a
+USING kpdb_corrections b
+WHERE b.field = 'remove'
+AND a.record_id = b.record_id;
+
 -- Correct project_id
 UPDATE kpdb."2020" a
 SET project_id = b.new_value
@@ -156,3 +162,5 @@ WHERE b.field = 'inactive'
 AND a.record_id = b.record_id 
 AND a.inactive = b.old_value
 AND (b.new_value::text IS IN ('0','1') OR b.new_value IS NULL);
+
+-- Add DOB or ZAP

--- a/knownprojects_build/sql/apply_corrections.sql
+++ b/knownprojects_build/sql/apply_corrections.sql
@@ -162,5 +162,3 @@ WHERE b.field = 'inactive'
 AND a.record_id = b.record_id 
 AND a.inactive = b.old_value
 AND (b.new_value::text IS IN ('0','1') OR b.new_value IS NULL);
-
--- Add DOB or ZAP

--- a/knownprojects_build/sql/dcp_housing.sql
+++ b/knownprojects_build/sql/dcp_housing.sql
@@ -77,7 +77,6 @@ CREATE TABLE dcp_housing_proj AS(
 	WITH geom_merge AS (
 		SELECT record_id, ST_UNION(geom) AS geom
 		FROM dcp_housing
-        WHERE units_gross <> '0'
 		GROUP BY record_id
 	)
 	SELECT b.source, b.record_id, b.record_name,

--- a/knownprojects_build/sql/dob_match.sql
+++ b/knownprojects_build/sql/dob_match.sql
@@ -28,6 +28,7 @@ filtered_dcp_housing_proj as (
     ON a.record_id = b.job_number
     WHERE a.type <> 'Demolition'
     AND a.status <> 'Withdrawn'
+    AND a.units_gross::int <> 0
     AND b.units_prop::int > 0
     AND NOT (a.type = 'Alteration'
         and a.units_gross::integer <= 0)

--- a/knownprojects_build/sql/update_combined_dob.sql
+++ b/knownprojects_build/sql/update_combined_dob.sql
@@ -21,7 +21,8 @@ select
     null as project_id,
     null as units_net,
     inactive, geom
-from dcp_housing_proj);
+from dcp_housing_proj
+WHERE dcp_housing_proj.units_gross::integer <> 0);
 
 VACUUM ANALYZE kpdb_gross."2020";
 


### PR DESCRIPTION
This contains a first attempt at adding DOB records based on field=add in the corrections file.
Note that this depends on rerunning dcp_housing.sql to recreate dcp_housing_proj table. Previously, the filtering of records with units_net = 0 happened when creating dcp_housing_proj. This means that filtered records didn't exist in the correct schema to grab them from dcp_housing_proj as a result of an 'add' row in the corrections file.

To get around this, I moved the filter out of dcp_housing_proj and into the dob_match.sql and update_combined_dob.sql. This way, dcp_housing_proj contains all DOB records, and can be used to fill in the previously-filtered records after manual review.

After adding new records, each gets a stand-alone project-ID. This will get overwritten by manual corrections in a later step if necessary. Phasing, status normalization, bool flags, and borough calculations get reapplied for the new DOB rows.