### PR TITLE
Add borough field to correct shifted rows

### DIFF
--- a/knownprojects_build/sql/add_remaining_n_study.sql
+++ b/knownprojects_build/sql/add_remaining_n_study.sql
@@ -31,6 +31,7 @@ tmp as (
 		source,
         record_id,
         record_name,
+        NULL as borough,
         status,
         type,
         date,


### PR DESCRIPTION
Future N Studies and N Studies Projected Projects had columns shifted, making the units_net look like they were NULL.