### PR TITLE
Start with units_net = units_gross before deduplication

### DIFF
--- a/knownprojects_build/python/resolve_clusters.py
+++ b/knownprojects_build/python/resolve_clusters.py
@@ -26,6 +26,7 @@ def subtract_units(row, group):
 
 def resolve_project(group):
     if group.shape[0] > 1:
+        group = group.sort_values('source_id')
         group = group.reset_index()
         for index, row in group.iterrows():
             group.iloc[index] = subtract_units(row, group)

--- a/knownprojects_build/python/resolve_clusters.py
+++ b/knownprojects_build/python/resolve_clusters.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
 
     df = pd.read_sql(f'SELECT * FROM {sys.argv[1]}."{year}"', build_engine)
     df['units_gross'] = df['units_gross'].astype(float)
-    df['units_net'] = df['units_net'].astype(float)
+    df['units_net'] = df['units_gross'].astype(float)
     resolved = resolve_all_projects(df)
 
     DDL = {"project_id":"text",


### PR DESCRIPTION
Fixes an error where units_net still contained 0 for automatically deduped records (part of the cluster review process), even after project_ids and units_gross got edited through manual review.

Also sorts records in each project by hierarchy prior to deduplication, so that each lower-certainty source has the already corrected units_net subtracted from it.