### PR TITLE
Add logic to overwrite units_net with corrections file

### DIFF
--- a/knownprojects_build/05_corrections.sh
+++ b/knownprojects_build/05_corrections.sh
@@ -34,5 +34,9 @@ docker run --rm\
         pip3 install -r python/requirements.txt; 
         python3 python/resolve_clusters.py kpdb kpdb"
 
+# Overwrite automatically calculated units_net
+echo "Force-setting units_net"
+psql $BUILD_ENGINE -f sql/correct_units_net.sql
+
 echo "Calculating count phasing fields"
 psql $BUILD_ENGINE -f sql/phasing_counts.sql

--- a/knownprojects_build/sql/correct_units_net.sql
+++ b/knownprojects_build/sql/correct_units_net.sql
@@ -1,0 +1,8 @@
+-- Force a correction of units_net
+
+UPDATE kpdb."2020" a
+SET units_net = b.new_value::numeric
+FROM kpdb_corrections.latest b
+WHERE b.field = 'units_net'
+AND a.record_id = b.record_id 
+AND ((a.units_net::numeric = b.old_value::numeric) OR (a.units_net IS NULL and b.old_value IS NULL));


### PR DESCRIPTION
Overwrite units net when necessary. This occurs after automatic deduplication, and before the calculation of the unit-count phasing fields.