### PR TITLE
Assign stand-alone project_ids to planner-added projects

### DIFF
--- a/knownprojects_build/05_corrections.sh
+++ b/knownprojects_build/05_corrections.sh
@@ -20,6 +20,10 @@ psql $BUILD_ENGINE -f sql/apply_corrections.sql
 echo "Recalculating borough"
 psql $BUILD_ENGINE -f sql/assign_boro.sql
 
+# Create stand-alone project IDs for newly added projects
+echo "Create stand-alone project_ids"
+psql $BUILD_ENGINE -f sql/stand_alone_project_id.sql
+
 # Recalculate units_net & phasing counts
 echo "Deduplicating units"
 docker run --rm\

--- a/knownprojects_build/sql/add_new_records.sql
+++ b/knownprojects_build/sql/add_new_records.sql
@@ -92,22 +92,3 @@ from new_zap a
 left join geometry b
 on (a.record_id = b.record_id);
 
--- Assign stand-alone project IDs for new additions
-WITH
-max_proj AS (
-	SELECT max(LTRIM(split_part(project_id, '-', 1), 'p')::integer) AS max_proj_number
-    FROM kpdb."2020"),
-tmp AS (
-	SELECT
-        a.source,
-        a.record_id,
-		a.record_name,
-        'p'||(ROW_NUMBER() OVER (ORDER BY record_id) + b.max_proj_number)::text||'-1' as project_id
-    FROM kpdb."2020" a, max_proj b
-    WHERE a.project_id IS NULL)
-UPDATE kpdb."2020" a
-	SET project_id = b.project_id
-	FROM tmp b
-	WHERE a.source = b.source
-	AND a.record_id::text = b.record_id::text
-	AND a.record_name::text = b.record_name::text;

--- a/knownprojects_build/sql/append_planner_added.sql
+++ b/knownprojects_build/sql/append_planner_added.sql
@@ -33,23 +33,3 @@ SELECT 'DCP Planner-Added Projects' as source,
         project_id FROM dcp_planneradded.latest
 WHERE record_id NOT IN (SELECT DISTINCT record_id FROM kpdb."2020")
 AND omit IS NULL;
-
--- Assign stand-alone project IDs for new additions
-WITH
-max_proj AS (
-	SELECT max(LTRIM(split_part(project_id, '-', 1), 'p')::integer) AS max_proj_number
-    FROM kpdb."2020"),
-tmp AS (
-	SELECT
-        a.source,
-        a.record_id,
-		a.record_name,
-        'p'||(ROW_NUMBER() OVER (ORDER BY record_id) + b.max_proj_number)::text||'-1' as project_id
-    FROM kpdb."2020" a, max_proj b
-    WHERE a.project_id IS NULL)
-UPDATE kpdb."2020" a
-	SET project_id = b.project_id
-	FROM tmp b
-	WHERE a.source = b.source
-	AND a.record_id::text = b.record_id::text
-	AND a.record_name::text = b.record_name::text;

--- a/knownprojects_build/sql/append_planner_added.sql
+++ b/knownprojects_build/sql/append_planner_added.sql
@@ -15,7 +15,7 @@ INSERT INTO kpdb."2020" (source,
                                 inactive,
                                 project_id
                                 )
-(SELECT 'DCP Planner-Added Projects' as source,
+SELECT 'DCP Planner-Added Projects' as source,
         record_id,
         record_name,
         borough, 
@@ -32,4 +32,24 @@ INSERT INTO kpdb."2020" (source,
         inactive,
         project_id FROM dcp_planneradded.latest
 WHERE record_id NOT IN (SELECT DISTINCT record_id FROM kpdb."2020")
-AND omit IS NULL);
+AND omit IS NULL;
+
+-- Assign stand-alone project IDs for new additions
+WITH
+max_proj AS (
+	SELECT max(LTRIM(split_part(project_id, '-', 1), 'p')::integer) AS max_proj_number
+    FROM kpdb."2020"),
+tmp AS (
+	SELECT
+        a.source,
+        a.record_id,
+		a.record_name,
+        'p'||(ROW_NUMBER() OVER (ORDER BY record_id) + b.max_proj_number)::text||'-1' as project_id
+    FROM kpdb."2020" a, max_proj b
+    WHERE a.project_id IS NULL)
+UPDATE kpdb."2020" a
+	SET project_id = b.project_id
+	FROM tmp b
+	WHERE a.source = b.source
+	AND a.record_id::text = b.record_id::text
+	AND a.record_name::text = b.record_name::text;

--- a/knownprojects_build/sql/stand_alone_project_id.sql
+++ b/knownprojects_build/sql/stand_alone_project_id.sql
@@ -1,0 +1,19 @@
+-- Assign stand-alone project IDs for new additions
+WITH
+max_proj AS (
+	SELECT max(LTRIM(split_part(project_id, '-', 1), 'p')::integer) AS max_proj_number
+    FROM kpdb."2020"),
+tmp AS (
+	SELECT
+        a.source,
+        a.record_id,
+		a.record_name,
+        'p'||(ROW_NUMBER() OVER (ORDER BY record_id) + b.max_proj_number)::text||'-1' as project_id
+    FROM kpdb."2020" a, max_proj b
+    WHERE a.project_id IS NULL)
+UPDATE kpdb."2020" a
+	SET project_id = b.project_id
+	FROM tmp b
+	WHERE a.source = b.source
+	AND a.record_id::text = b.record_id::text
+	AND a.record_name::text = b.record_name::text;


### PR DESCRIPTION
Fixes bug where planner-added projects were not in final output because they didn't have project_ids