### PR TITLE
allowing specifying the name of the corrections table

### DIFF
--- a/knownprojects_build/02_build.sh
+++ b/knownprojects_build/02_build.sh
@@ -9,7 +9,7 @@ psql $BUILD_ENGINE -1 -f _sql/_procedures.sql
 psql $BUILD_ENGINE -1 -f _sql/dcp_application.sql
 psql $BUILD_ENGINE -1 -f _sql/dcp_housing.sql
 psql $BUILD_ENGINE -1 -f _sql/combine.sql
-psql $BUILD_ENGINE -1 -c "CALL apply_correction('_combined');"
+psql $BUILD_ENGINE -1 -c "CALL apply_correction('_combined', 'corrections_main');"
 psql $BUILD_ENGINE -c "VACUUM ANALYZE _combined;"
 
 # Find and matches between non-DOB sources
@@ -28,7 +28,7 @@ psql $BUILD_ENGINE -c "VACUUM ANALYZE project_record_ids;"
 
 # Dedup units
 python3 -m _python.dedup_units
-psql $BUILD_ENGINE -1 -c "CALL apply_correction('dedup_units');"
+psql $BUILD_ENGINE -1 -c "CALL apply_correction('dedup_units', 'corrections_main');"
 psql $BUILD_ENGINE -c "VACUUM ANALYZE dedup_units;"
 
 # Create KPDB


### PR DESCRIPTION
this will be useful when we have needs to do geometry corrections. 
e.g. we can just call
`psql $BUILD_ENGINE -1 -c "CALL apply_correction('_combined', 'corrections_geo');"`

for all other fields:
`psql $BUILD_ENGINE -1 -c "CALL apply_correction('_combined', 'corrections_main');"`

#253