### PR TITLE
Removing logic for text search and use Corrections_ZAP

### DIFF
--- a/knownprojects_build/sql/create_corrections.sql
+++ b/knownprojects_build/sql/create_corrections.sql
@@ -32,3 +32,15 @@ CREATE TABLE corrections_main(
 );
 
 \COPY corrections_main FROM 'data/corrections/corrections_main.csv' DELIMITER ',' CSV HEADER;
+
+-- corrections zap table -> indicating if each record should be added / removed from kpdb
+DROP TABLE IF EXISTS corrections_zap;
+CREATE TABLE corrections_zap(
+    record_id text,
+    action text,
+    editor text,
+    date text,
+    notes text
+);
+
+\COPY corrections_zap FROM 'data/corrections/corrections_zap.csv' DELIMITER ',' CSV HEADER;

--- a/knownprojects_build/sql/dcp_application.sql
+++ b/knownprojects_build/sql/dcp_application.sql
@@ -5,11 +5,10 @@ DESCRIPTION:
 INPUTS:
 	dcp_projects
 	dcp_projectactions
-    dcp_project_bbls
-    dcp_mappluto_wi
-    dcp_knownprojects
-    corrections_main
-    DEPRECATING: kpdb_<last_version>.dcp_project
+    	dcp_project_bbls
+    	dcp_mappluto_wi
+    	dcp_knownprojects
+    	corrections_main
 OUTPUTS: 
 	dcp_application
 */
@@ -173,17 +172,15 @@ _dcp_application as (
         select dcp_name from records_last_kpdb)
     	THEN 1 ELSE 0 END) as flag_in_last_kpdb,
 
-	(CASE WHEN dcp_name not in (
+    (CASE WHEN dcp_name not in (
         select dcp_name from records_last_kpdb) 
 		THEN 1 ELSE 0 END) as flag_not_in_last_kpdb,
 
-	(CASE 
-		WHEN dcp_name in (select dcp_name from records_corr_remove) THEN 'remove' 
-		WHEN dcp_name in (select dcp_name from records_corr_add) THEN 'add' 
-	END) as flag_corrected,
+    (CASE 
+	WHEN dcp_name in (select dcp_name from records_corr_remove) THEN 'remove' 
+	WHEN dcp_name in (select dcp_name from records_corr_add) THEN 'add' 
+     END) as flag_corrected,
 
-	-- (CASE WHEN dcp_name not in (select record_id from records_last_dcp_project) 
-	-- 	THEN 1 ELSE 0 END) as flag_new_in_zap,
     dcp_name as record_id,
     dcp_projectname as record_name,
     dcp_projectbrief, 
@@ -191,11 +188,11 @@ _dcp_application as (
     dcp_borough as borough,
     statuscode,
     (case
-		when dcp_projectphase ~* 'project completed' then 'DCP 4: Zoning Implemented'
-		when dcp_projectphase ~* 'pre-pas|pre-cert' then 'DCP 2: Application in progress'
-		when dcp_projectphase ~* 'initiation' then 'DCP 1: Expression of interest'
-		when dcp_projectphase ~* 'public review' then 'DCP 3: Certified/Referred'
-	end) as status,
+	when dcp_projectphase ~* 'project completed' then 'DCP 4: Zoning Implemented'
+	when dcp_projectphase ~* 'pre-pas|pre-cert' then 'DCP 2: Application in progress'
+	when dcp_projectphase ~* 'initiation' then 'DCP 1: Expression of interest'
+	when dcp_projectphase ~* 'public review' then 'DCP 3: Certified/Referred'
+    end) as status,
     dcp_publicstatus as publicstatus,
     dcp_certifiedreferred,
     dcp_applicanttype as applicanttype,

--- a/knownprojects_build/sql/dcp_application.sql
+++ b/knownprojects_build/sql/dcp_application.sql
@@ -122,8 +122,7 @@ consolidated_add_filter as (
 	/*
 	Add if a record satisfies:
 	1) flagged as add in corrections_zap.csv
-	2) flag_year = 1
-	3) flag_status = 1
+	2) or ( flag_year = 1 and flag_status = 1 ) 
 	*/
     SELECT distinct dcp_name FROM zap_translated a
     WHERE dcp_name IN (SELECT dcp_name FROM status_filter)
@@ -134,7 +133,7 @@ consolidated_remove_filter as (
 	/*
 	Remove if a record satisfies:
 	1) flagged as remove in corrections_zap.csv
-	2) not in consolidated_add_filter
+	2) or not in consolidated_add_filter
 	*/
 	SELECT dcp_name FROM records_corr_remove UNION
     SELECT dcp_name as dcp_name FROM zap_translated

--- a/knownprojects_build/sql/dcp_application.sql
+++ b/knownprojects_build/sql/dcp_application.sql
@@ -110,13 +110,13 @@ records_last_kpdb as (
 ),
 records_corr_remove as (
 	SELECT record_id as dcp_name
-	FROM corrections_main
-	WHERE field = 'remove'
+	FROM corrections_zap
+	WHERE lower(action) = 'remove'
 ),
 records_corr_add as (
 	SELECT record_id as dcp_name
-	FROM corrections_main
-	WHERE field = 'add'
+	FROM corrections_zap
+	WHERE lower(action) = 'add'
 ),
 consolidated_add_filter as (
 	/*


### PR DESCRIPTION
#276  

logic is complete, we just need HED to create the `corrections_zap.csv`

![image](https://user-images.githubusercontent.com/13207770/111825609-07be2e00-88be-11eb-837b-b48fcac80ea8.png)
current logic adds everything that's indicated as add and removes everything as remove
also includes records that satisfy flag_year, flag_status
https://github.com/NYCPlanning/db-knownprojects-data/pull/18