### PR TITLE
Update PAT for Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,22 +38,12 @@ jobs:
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
-      GH_PAT: ${{ secrets.GH_PAT }}
+      TD_PAT: ${{ secrets.TD_PAT }}
       AUTHOR: Data Engineering
     steps:
-      # - name: Install SSH key
-      #   uses: shimataro/ssh-key-action@v2
-      #   with:
-      #     key: ${{ secrets.SSH_KEY }}
-      #     #name: id_rsa # optional
-      #     known_hosts: ${{ secrets.KNOWN_HOSTS }}
-      #     #config: ${{ secrets.CONFIG }} # ssh_config; optional
-      #     if_key_exists: fail
-
       - uses: actions/checkout@v2
         with: 
             submodules: true
-            #ssh-key: ssh-keyscan github.com
             token: ${{ secrets.TD_PAT }}
             persist-credentials: true
 
@@ -89,7 +79,7 @@ jobs:
         uses: actions/github-script@v3
         if: github.event.inputs.export == 'yes' && github.event.inputs.comments != ''
         with: 
-          github-token: ${{ secrets.GH_PAT }}
+          github-token: ${{ secrets.TD_PAT }}
           script: |
             github.issues.createComment({
               issue_number: ${{ steps.export.outputs.issue_number }},

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,15 @@ jobs:
       GH_PAT: ${{ secrets.GH_PAT }}
       AUTHOR: Data Engineering
     steps:
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_KEY }}
+          #name: id_rsa # optional
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+          #config: ${{ secrets.CONFIG }} # ssh_config; optional
+          if_key_exists: fail
+          
       - uses: actions/checkout@v2
         with: 
             submodules: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,19 +41,19 @@ jobs:
       GH_PAT: ${{ secrets.GH_PAT }}
       AUTHOR: Data Engineering
     steps:
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.SSH_KEY }}
-          #name: id_rsa # optional
-          known_hosts: ${{ secrets.KNOWN_HOSTS }}
-          #config: ${{ secrets.CONFIG }} # ssh_config; optional
-          if_key_exists: fail
-          
+      # - name: Install SSH key
+      #   uses: shimataro/ssh-key-action@v2
+      #   with:
+      #     key: ${{ secrets.SSH_KEY }}
+      #     #name: id_rsa # optional
+      #     known_hosts: ${{ secrets.KNOWN_HOSTS }}
+      #     #config: ${{ secrets.CONFIG }} # ssh_config; optional
+      #     if_key_exists: fail
+
       - uses: actions/checkout@v2
         with: 
             submodules: true
-            ssh-key: ${{ secrets.SSH_KEY }}
+            # ssh-key: ${{ secrets.SSH_KEY }}
             persist-credentials: true
 
       - name: Update Submodule

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,8 @@ jobs:
       - uses: actions/checkout@v2
         with: 
             submodules: true
-            ssh-key: ssh-keyscan github.com
+            #ssh-key: ssh-keyscan github.com
+            token: ${{ secrets.GH_PAT }}
             persist-credentials: true
 
       - name: Update Submodule

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
         with: 
             submodules: true
             #ssh-key: ssh-keyscan github.com
-            token: ${{ secrets.GH_PAT }}
+            token: ${{ secrets.TD_PAT }}
             persist-credentials: true
 
       - name: Update Submodule

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
         with: 
             submodules: true
-            # ssh-key: ${{ secrets.SSH_KEY }}
+            ssh-key: ssh-keyscan github.com
             persist-credentials: true
 
       - name: Update Submodule

--- a/python/upload.py
+++ b/python/upload.py
@@ -5,7 +5,7 @@ import glob
 import sys
 
 # Initialize github and repo
-g = Github(os.environ.get("GH_PAT"), timeout=60, retry=10)
+g = Github(os.environ.get("TD_PAT"), timeout=60, retry=10)
 repo = g.get_repo("NYCPlanning/db-knownprojects-data")
 
 


### PR DESCRIPTION
addressed #374 one reviewer required 🐬 

After some digging, it was found the root causes of the [failed Github Actions runs](https://github.com/NYCPlanning/db-knownprojects/actions/runs/3534618421) were due to the repo access token were outdated. The solution is to create new organization access token then replace the `GH_PAT` and also depreciate the use of `SSH_KEY` for pulling the main repo. It is worth to note that this token will likely need to be periodically updated and maintained by a user that belongs to the organization. Although we are also likely to replace the use of submodule entirely and data library so it may not be an issue for the long term.

Check [here](https://github.com/NYCPlanning/db-knownprojects-data/pull/185) for successful output from this branch

See this new [wiki page](https://github.com/NYCPlanning/db-knownprojects/wiki/Github-Actions-Workflow-Access-Token) for documentation on update the PAT. 



