### PR TITLE
fix build action failing during export step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ static
 
 # 
 */output
+.python-version

--- a/python/upload.py
+++ b/python/upload.py
@@ -33,7 +33,9 @@ def upload_file(path_local: str, path_repo: str, target_branch: str, message: st
     print(f"uploading: {path_local} (local) to {path_repo} (repo) ...")
 
     contents_old = repo.get_contents(path_repo, ref=target_branch)
-    print(f"length of old contents: {len(contents_old.content)}")
+    print(f"old contents path: {contents_old.path}")
+    print(f"old contents sha: {contents_old.sha}")
+    print(f"old contents length: {len(contents_old.content)}")
 
     repo.create_file(path_repo, message, content, branch=target_branch)
     print(f"uploaded: {path_repo}")
@@ -59,7 +61,7 @@ if __name__ == "__main__":
 
     # Upload files one by one
     for _file in file_list:
-        _file_repo = _file.replace(basepath, "")
+        _file_repo = _file.replace(basepath + "/", "")
         message = f"🚀 {target_branch} -> {_file_repo}..."
         upload_file(_file, _file_repo, target_branch, message)
 

--- a/python/upload.py
+++ b/python/upload.py
@@ -30,15 +30,15 @@ def upload_file(path_local: str, path_repo: str, target_branch: str, message: st
     """
     with open(path_local, "rb") as f:
         content = f.read()
-    print(f"uploading: {path_repo} ...")
+    print(f"uploading: {path_local} (local) to {path_repo} (repo) ...")
     repo.create_file(path_repo, message, content, branch=target_branch)
     print(f"uploaded: {path_repo}")
 
 
 def create_pull_request(title: str, body: str, head: str, base: str = "main"):
     pr = repo.create_pull(title=title, body=body, head=head, base=base)
-    print(pr.number)
     os.system(f'echo "::set-output name=issue_number::{pr.number}"')
+    print(f"Created PR with PR number: {pr.number}")
 
 if __name__ == "__main__":
     # List all files under output

--- a/python/upload.py
+++ b/python/upload.py
@@ -20,24 +20,34 @@ def create_new_branch(target_branch: str, source_branch: str = "main"):
     print(f"created branch: {ref_target_branch}")
 
 
-def upload_file(path_local: str, path_repo: str, target_branch: str, message: str = ""):
+def upload_file(path_local: str, target_branch: str):
     """
     this function will upload a given file to a given target_branch
     path_local: local file path relative to knownprojects_build
-    path_repo: relative file path within in the repo
     target_branch: the branch to commit files to
-    message: commit message that goes along with the file upload
     """
+    # relative file path within the repo
+    path_repo = _file.replace(basepath + "/", "")
+    # commit message that goes along with the file upload
+    message = f"🚀 {target_branch} -> {path_repo}..."
+
     with open(path_local, "rb") as f:
         content = f.read()
-    print(f"uploading: {path_local} (local) to {path_repo} (repo) ...")
+    print(f"uploading: {path_local} (local) to {target_branch}/{path_repo} (repo) ...")
 
-    contents_old = repo.get_contents(path_repo, ref=target_branch)
-    print(f"old contents path: {contents_old.path}")
-    print(f"old contents sha: {contents_old.sha}")
-    print(f"old contents length: {len(contents_old.content)}")
+    # DEV try to get contents of non-existent file
+    path_repo_bad = "output/no_file.zip"
+    contents_existing = repo.get_contents(path_repo_bad, ref=target_branch)
+    print(f"exisiting contents path: {contents_existing.path}")
+    print(f"exisiting contents sha: {contents_existing.sha}")
+    repo.create_file(path_repo_bad, message, content, branch=target_branch)
 
-    repo.create_file(path_repo, message, content, branch=target_branch)
+    contents_existing = repo.get_contents(path_repo, ref=target_branch)
+    print(f"exisiting contents path: {contents_existing.path}")
+    print(f"exisiting contents sha: {contents_existing.sha}")
+    repo.update_file(contents_existing.path, message, content, contents_existing.sha, branch=target_branch)
+
+
     print(f"uploaded: {path_repo}")
 
 
@@ -61,9 +71,7 @@ if __name__ == "__main__":
 
     # Upload files one by one
     for _file in file_list:
-        _file_repo = _file.replace(basepath + "/", "")
-        message = f"🚀 {target_branch} -> {_file_repo}..."
-        upload_file(_file, _file_repo, target_branch, message)
+        upload_file(_file, target_branch)
 
     # Create a PR after upload
     md_file_list = "\n".join([f" - `{f.replace(basepath+'/', '')}`" for f in file_list])

--- a/python/upload.py
+++ b/python/upload.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 
     # Upload files one by one
     for _file in file_list:
-        _file_repo = _file.replace(basepath + "/", "")  # TODO try removing "/" to include it in create_file
+        _file_repo = _file.replace(basepath, "")
         message = f"🚀 {target_branch} -> {_file_repo}..."
         upload_file(_file, _file_repo, target_branch, message)
 

--- a/python/upload.py
+++ b/python/upload.py
@@ -33,7 +33,7 @@ def upload_file(path_local: str, path_repo: str, target_branch: str, message: st
     print(f"uploading: {path_local} (local) to {path_repo} (repo) ...")
 
     contents_old = repo.get_contents(path_repo, ref=target_branch)
-    print(f"length of old contents: {len(contents_old)}")
+    print(f"length of old contents: {len(contents_old.content())}")
 
     repo.create_file(path_repo, message, content, branch=target_branch)
     print(f"uploaded: {path_repo}")

--- a/python/upload.py
+++ b/python/upload.py
@@ -31,6 +31,10 @@ def upload_file(path_local: str, path_repo: str, target_branch: str, message: st
     with open(path_local, "rb") as f:
         content = f.read()
     print(f"uploading: {path_local} (local) to {path_repo} (repo) ...")
+
+    contents_old = repo.get_contents(path_repo, ref=target_branch)
+    print(f"length of old contents: {len(contents_old)}")
+
     repo.create_file(path_repo, message, content, branch=target_branch)
     print(f"uploaded: {path_repo}")
 

--- a/python/upload.py
+++ b/python/upload.py
@@ -33,7 +33,7 @@ def upload_file(path_local: str, path_repo: str, target_branch: str, message: st
     print(f"uploading: {path_local} (local) to {path_repo} (repo) ...")
 
     contents_old = repo.get_contents(path_repo, ref=target_branch)
-    print(f"length of old contents: {len(contents_old.content())}")
+    print(f"length of old contents: {len(contents_old.content)}")
 
     repo.create_file(path_repo, message, content, branch=target_branch)
     print(f"uploaded: {path_repo}")
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 
     # Upload files one by one
     for _file in file_list:
-        _file_repo = _file.replace(basepath + "/", "")
+        _file_repo = _file.replace(basepath + "/", "")  # TODO try removing "/" to include it in create_file
         message = f"🚀 {target_branch} -> {_file_repo}..."
         upload_file(_file, _file_repo, target_branch, message)
 

--- a/python/upload.py
+++ b/python/upload.py
@@ -28,10 +28,10 @@ def upload_file(path_local: str, path_repo: str, target_branch: str, message: st
     target_branch: the branch to commit files to
     message: commit message that goes along with the file upload
     """
-    src = repo.get_branch(target_branch)
     with open(path_local, "rb") as f:
         content = f.read()
-    repo.create_file(path_repo, message, content, branch=target_branch, sha=src.commit.sha)
+    print(f"uploading: {path_repo} ...")
+    repo.create_file(path_repo, message, content, branch=target_branch)
     print(f"uploaded: {path_repo}")
 
 

--- a/python/upload.py
+++ b/python/upload.py
@@ -14,8 +14,10 @@ def create_new_branch(target_branch: str, source_branch: str = "main"):
     This function will create a new branch based on source_branch,
     named after target_branch. source_branch is default to main
     """
+    ref_target_branch = f"refs/heads/{target_branch}"
     src = repo.get_branch(source_branch)
-    repo.create_git_ref(ref=f"refs/heads/{target_branch}", sha=src.commit.sha)
+    repo.create_git_ref(ref=ref_target_branch, sha=src.commit.sha)
+    print(f"created branch: {ref_target_branch}")
 
 
 def upload_file(path_local: str, path_repo: str, target_branch: str, message: str = ""):
@@ -26,9 +28,10 @@ def upload_file(path_local: str, path_repo: str, target_branch: str, message: st
     target_branch: the branch to commit files to
     message: commit message that goes along with the file upload
     """
+    src = repo.get_branch(target_branch)
     with open(path_local, "rb") as f:
         content = f.read()
-    repo.create_file(path_repo, message, content, branch=target_branch)
+    repo.create_file(path_repo, message, content, branch=target_branch, sha=src.commit.sha)
     print(f"uploaded: {path_repo}")
 
 

--- a/python/upload.py
+++ b/python/upload.py
@@ -5,6 +5,7 @@ import glob
 import sys
 
 # Initialize github and repo
+# NOTE USES db-knownprojects-data REPO. NOT THIS REPO.
 g = Github(os.environ.get("ARD_PAT"), timeout=60, retry=10)
 repo = g.get_repo("NYCPlanning/db-knownprojects-data")
 


### PR DESCRIPTION
## changes
- during export step, check if file exists and either use `update_file()` or `create_file()`
- refine print statements and `upload_file()` logic
- add `.python-version` to `.gitignore` due to local dev setup

## notes
- [successful Build run](https://github.com/NYCPlanning/db-knownprojects/actions/runs/4057735486/jobs/6983833504)
- PR in data repo https://github.com/NYCPlanning/db-knownprojects-data/pull/218
- [Link to output files](https://github.com/NYCPlanning/db-knownprojects-data/tree/output-20230131-1951/output) in relevant branch in data repo
- cause of issue was the merging of an output branch to main in the data repo. this added the `output/` folder to the main branch. rather than delete it, decided to expect this and update files in new output branches to allow for merging of such branches