### PR TITLE
do not export data when build is triggered by push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
       export:
         description: 'Would you like to export outputs to db-knownprojects-data? (yes/no)'
         required: false
-        default: 'yes'
+        default: 'no'
       comments:
         description: 'Provide any additional comments below'
         required: false


### PR DESCRIPTION
## changes
* set export input default to `no`

## notes
* noticed [a new branch/PR in the data repo](https://github.com/NYCPlanning/db-knownprojects-data/pull/219) was created in when [a branch was merged to dev in this repo](https://github.com/NYCPlanning/db-knownprojects-data/pull/219)
* that is undesirable and caused by the combination of all commit pushes triggering the build action and the export input defaulting to `yes`
* seems worth keeping the `push` trigger to automatically run test builds on feature branches
* will close that errant PR in the data repo after this approach is reviewed