### PR TITLE
do not export data on commits to dev branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: 3. export ...
         id: export
-        if: github.event.inputs.export == 'yes' || github.ref == 'refs/heads/dev'
+        if: github.event.inputs.export == 'yes'
         run: ./kpdb.sh export ${{ github.event.sender.login }}
 
       - name: 4. comment on PR


### PR DESCRIPTION
## motivation
* commits and merges shouldn't trigger data exports and PR creation in the Know Projects data repo

## changes
* remove the OR condition of that triggers the export stage, allowing for testing without exporting

## notes
* I missed a second necessary change in https://github.com/NYCPlanning/db-knownprojects/pull/390
* will close [this unintentional PR in the data repo](https://github.com/NYCPlanning/db-knownprojects-data/pull/220) when this PR is merged and successfully doesn't export data